### PR TITLE
Corrected behat test for revisions page

### DIFF
--- a/tests/behat/features/BasicPage.feature
+++ b/tests/behat/features/BasicPage.feature
@@ -38,5 +38,5 @@ Feature: Basic Page
   Scenario: Access the revisions page
     Given I am logged in as a user with the "Site Manager" role
     And I am viewing a "stanford_page" with the title "I would like revisions"
-    Then I click "Revisions"
+    Then I click "Version History"
     And the response status code should be 200


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The title of the revisions link changed, and the behat test failed as a result.  This corrects the test.

# Needed By (Date)
- ASAP
