### PR TITLE
D8CORE-000: Set cards to 3 in a row.

### DIFF
--- a/config/sync/field.field.node.stanford_page.su_page_components.yml
+++ b/config/sync/field.field.node.stanford_page.su_page_components.yml
@@ -42,7 +42,7 @@ settings:
       stanford_banner:
         min: '12'
       stanford_card:
-        min: '3'
+        min: '4'
       stanford_media_caption:
         min: '3'
       stanford_wysiwyg:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changes the react_paragraphs setting to set cards to be a max of three in a row.

# Needed By (Date)
- Asap

# Urgency
- High

# Steps to Test

1. Import this config
2. Clear caches
3. Validate you can only put three cards in a row on a basic page.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- Related https://github.com/SU-SWS/stanford_profile/pull/206

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
