### PR TITLE
D8CORE-000: Set media with caption and wysiwyg to 3 in a row.

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_page.default.yml
@@ -78,7 +78,7 @@ content:
   su_page_components:
     weight: 9
     settings:
-      items_per_row: 4
+      items_per_row: 3
       resizable: false
     third_party_settings: {  }
     type: react_paragraphs

--- a/config/sync/field.field.node.stanford_page.su_page_components.yml
+++ b/config/sync/field.field.node.stanford_page.su_page_components.yml
@@ -44,7 +44,7 @@ settings:
       stanford_card:
         min: '4'
       stanford_media_caption:
-        min: '3'
+        min: '4'
       stanford_wysiwyg:
-        min: '3'
+        min: '4'
 field_type: react_paragraphs


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Sets media with caption and WYSIWYG paragraphs to a max of 3 in a row.

# Needed By (Date)
- ASAP. Today.

# Urgency
- Today

# Steps to Test

1. Check out this branch
2. Import config
3. Attempt to add more than three of a row of anything on a page.

# Affected Projects or Products
- This.

# Associated Issues and/or People
- https://stanfordwebservices.slack.com/archives/GJQJ7HTK7/p1589934224004800

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
