### PR TITLE
removing 403 and 404 pages from xmlsitemap

### DIFF
--- a/soe_profile.profile
+++ b/soe_profile.profile
@@ -245,19 +245,16 @@ function soe_profile_xmlsitemap_link_alter(array &$link, array $context) {
 
   // Get 404 page path
   $soe_profile_404_page = \Drupal::state()->get('soe_profile.404_page');
-  
+
   // If node id matches 403 or 404 pages, remove it from sitemap.
   switch ($node_id) {
     case $soe_profile_403_page:
       // Status is set to zero to exclude the item in the sitemap.
       $link['status'] = 0;
-      // Set to zero to make the element non-accessible by the anonymous user.
-      $link['access'] = 0;
+
     case $soe_profile_404_page:
       // Status is set to zero to exclude the item in the sitemap.
       $link['status'] = 0;
-      // Set to zero to make the element non-accessible by the anonymous user.
-      $link['access'] = 0;
 
   }
 }

--- a/soe_profile.profile
+++ b/soe_profile.profile
@@ -226,3 +226,38 @@ function soe_profile_config_pages_presave(ConfigPagesInterface $entity) {
     \Drupal::state()->set('xmlsitemap_base_url', $url_field[0]['uri']);
   }
 }
+
+/**
+ * Alter the data of a sitemap link before the link is saved.
+ *
+ * @param array $link
+ *   An array with the data of the sitemap link.
+ * @param array $context
+ *   An optional context array containing data related to the link.
+ */
+function soe_profile_xmlsitemap_link_alter(array &$link, array $context) {
+
+  // Get node/[:id] from loc.
+  $node_id = $link['loc'];
+
+  // Get 403 page path
+  $soe_profile_403_page = \Drupal::state()->get('soe_profile.403_page');
+
+  // Get 404 page path
+  $soe_profile_404_page = \Drupal::state()->get('soe_profile.404_page');
+  
+  // If node id matches 403 or 404 pages, remove it from sitemap.
+  switch ($node_id) {
+    case $soe_profile_403_page:
+      // Status is set to zero to exclude the item in the sitemap.
+      $link['status'] = 0;
+      // Set to zero to make the element non-accessible by the anonymous user.
+      $link['access'] = 0;
+    case $soe_profile_404_page:
+      // Status is set to zero to exclude the item in the sitemap.
+      $link['status'] = 0;
+      // Set to zero to make the element non-accessible by the anonymous user.
+      $link['access'] = 0;
+
+  }
+}

--- a/soe_profile.profile
+++ b/soe_profile.profile
@@ -249,9 +249,6 @@ function soe_profile_xmlsitemap_link_alter(array &$link, array $context) {
   // If node id matches 403 or 404 pages, remove it from sitemap.
   switch ($node_id) {
     case $soe_profile_403_page:
-      // Status is set to zero to exclude the item in the sitemap.
-      $link['status'] = 0;
-
     case $soe_profile_404_page:
       // Status is set to zero to exclude the item in the sitemap.
       $link['status'] = 0;

--- a/soe_profile.profile
+++ b/soe_profile.profile
@@ -241,10 +241,10 @@ function soe_profile_xmlsitemap_link_alter(array &$link, array $context) {
   $node_id = $link['loc'];
 
   // Get 403 page path
-  $soe_profile_403_page = \Drupal::state()->get('soe_profile.403_page');
+  $soe_profile_403_page = \Drupal::config('system.site')->get('page.403');
 
   // Get 404 page path
-  $soe_profile_404_page = \Drupal::state()->get('soe_profile.404_page');
+  $soe_profile_404_page = \Drupal::config('system.site')->get('page.404');
 
   // If node id matches 403 or 404 pages, remove it from sitemap.
   switch ($node_id) {

--- a/tests/codeception/acceptance/Content/NewsCest.php
+++ b/tests/codeception/acceptance/Content/NewsCest.php
@@ -60,7 +60,7 @@ class NewsCest {
     $I->runDrush('cr');
     $I->amOnPage('/news');
     $I->click(".su-news-list__item a:first-of-type");
-    $I->seeCurrentUrlEquals('http://google.com/');
+    $I->seeCurrentUrlEquals('/');
 
     // See content as admin.
     $I->logInWithRole('administrator');

--- a/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
+++ b/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
@@ -17,9 +17,9 @@ class XmlsitemapCest {
     $host = \Drupal::request()->getSchemeAndHttpHost();
     $soe_profile_403_page = \Drupal::config('system.site')->get('page.403');
     $alias_403 = \Drupal::service('path.alias_manager')->getAliasByPath($soe_profile_403_page);
-    $I->dontSeeLink($host . $alias_403);
     $soe_profile_404_page = \Drupal::config('system.site')->get('page.404');
     $alias_404 = \Drupal::service('path.alias_manager')->getAliasByPath($soe_profile_404_page);
+    $I->dontSeeLink($host . $alias_403);
     $I->dontSeeLink($host . $alias_404);
   }
 

--- a/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
+++ b/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
@@ -9,6 +9,10 @@ class XmlsitemapCest {
    * Test that xmlsitemap is having 403 and 404 pages removed.
    */
   public function testSoeSitemapLinkAlter(AcceptanceTester $I) {
+    $I->logInWithRole('administrator');
+    $I->amOnPage("/admin/config/search/xmlsitemap/rebuild");
+    $I->click('Save configuration');
+    $I->runDrush('cr');
     $I->amOnPage("/sitemap.xml");
     $host = \Drupal::request()->getSchemeAndHttpHost();
     $soe_profile_403_page = \Drupal::config('system.site')->get('page.403');

--- a/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
+++ b/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test that soe_profile_xmlsitemap_link_alter is working.
+ */
+class XmlsitemapCest {
+
+  /**
+   * Test that xmlsitemap is having 403 and 404 pages removed.
+   */
+  public function testSoeSitemapLinkAlter(AcceptanceTester $I) {
+    $I->amOnPage("/sitemap.xml");
+    $host = \Drupal::request()->getSchemeAndHttpHost();
+    $soe_profile_403_page = \Drupal::config('system.site')->get('page.403');
+    $alias_403 = \Drupal::service('path.alias_manager')->getAliasByPath($soe_profile_403_page);
+    $I->dontSeeLink($host . $alias_403);
+    $soe_profile_404_page = \Drupal::config('system.site')->get('page.404');
+    $alias_404 = \Drupal::service('path.alias_manager')->getAliasByPath($soe_profile_404_page);
+    $I->dontSeeLink($host . $alias_404);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removing 403 and 404 pages from xmlsitemap

# Needed By (Date)
- ???

# Urgency
- low

# Steps to Test

1. on a build of lelelandd8 using soe_profile rebuild the xmlsitemap and verify the 403 and 404 pages are not in it.

# Affected Projects or Products
- soe_profile and associated sites

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/D8CORE-1989

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
