### PR TITLE
D8CORE-000: remove xmlsitemap patch, bump to 1.0.0, lose the alpha.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "drupal/view_unpublished": "^1.0@alpha",
         "drupal/views_block_filter_block": "^1.0@beta",
         "drupal/views_bulk_operations": "^3.6",
-        "drupal/xmlsitemap": "~1.0@alpha",
+        "drupal/xmlsitemap": "~1.0",
         "ext-imagick": "*",
         "su-soe/soe_basic": "dev-8.x-1.x",
         "su-sws/jumpstart_ui": "dev-8.x-1.x",
@@ -177,9 +177,6 @@
             },
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2019-08-10/paragraphs-set_langcode_widgets-290139_updated.patch"
-            },
-            "drupal/xmlsitemap": {
-                "https://www.drupal.org/project/xmlsitemap/issues/3100808": "https://www.drupal.org/files/issues/2019-12-13/3100808-2.patch"
             }
         }
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- the xmlsitemap module got a release, and no longer requires a patch.  This keeps composer from breaking on installs and updates.

# Needed By (Date)
- ASAP

# Urgency
- installs/updates that require the soe_profile will fail until we have it.

# Steps to Test

1. build a acsf-lelandd8 stack with this profile (you'll want to remove the `stanford_profile` requirement temporarily, since this patch is needed there too.
2. Run `composer update`.  Verify it succeeds.

# Affected Projects or Products
- These changes are included in https://github.com/SU-SWS/stanford_profile/pull/244
