### PR TITLE
D8CORE-2249: Initial commit for the SOE Events theming. Config files to support

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -46,8 +46,8 @@ third_party_settings:
         layout_id: defaults
         layout_settings:
           extra_classes: section-editorial-content
-          centered: centered-container
-          columns: default
+          centered: null
+          columns: flex-10-of-12
           label: 'Editorial Content'
         components:
           cee36061-b3bc-4171-92d5-299e62b7d0f2:

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -27,7 +27,7 @@ third_party_settings:
         layout_id: jumpstart_ui_one_column
         layout_settings:
           extra_classes: section-event-series--header
-          centered: centered-container
+          centered: null
           columns: flex-10-of-12
           label: Header
         components:

--- a/config/sync/page_manager.page_variant.event_series-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.event_series-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-event-series-list--header
-        centered: centered-container
-        columns: default
-        label: Header
+        label: 'Heading block'
       components:
         7e322eed-9186-4bef-9e88-f8364e0bd364:
           uuid: 7e322eed-9186-4bef-9e88-f8364e0bd364

--- a/config/sync/page_manager.page_variant.stanford_events_list-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_list-layout_builder-0.yml
@@ -16,15 +16,12 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-event-list--title
-        centered: centered-container
-        columns: default
-        label: 'Page Title'
+        label: 'Heading block'
       components:
-        611cbf70-b775-493c-9ec3-4af3397319fe:
-          uuid: 611cbf70-b775-493c-9ec3-4af3397319fe
+        a9c80694-4ed2-46aa-aae5-93e28a211682:
+          uuid: a9c80694-4ed2-46aa-aae5-93e28a211682
           region: main
           configuration:
             id: jumpstart_ui_page_heading

--- a/config/sync/page_manager.page_variant.stanford_events_past-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_past-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-events-past--header
-        centered: centered-container
-        columns: default
-        label: Header
+        label: 'Heading block'
       components:
         0f215804-4b92-45c1-a5ab-59eb3b7f3122:
           uuid: 0f215804-4b92-45c1-a5ab-59eb3b7f3122

--- a/config/sync/page_manager.page_variant.stanford_events_upcoming-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_upcoming-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-event-list--title
-        centered: centered-container
-        columns: default
-        label: 'Page Title'
+        label: 'Heading block'
       components:
         1d61c490-3289-422f-9025-c70415f7ed1b:
           uuid: 1d61c490-3289-422f-9025-c70415f7ed1b


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Sub theme work for the SOE Events module.
- Changed the pages to account for the gradients in css behind the headers. Taking this approach since we will not have our row/cell variants ready when the sites launch.

# Needed By (Date)
- Tuesday

# Urgency
- High

# Steps to Test
1. Pull in this branch
2. Pull in SOE Subtheming branch
3. Update configs
4. Recompile
5. Check on the Affect pages that they match the designs.

# Affected Projects or Products
- SOE Subtheming

# Affected Pages
/events/
/events/class (filtered lists)
/events/past
/event-series
/event/series/soe-event-series

# Associated Issues and/or People
- D8CORE-2247
- D8CORE-2248
- D8CORE-2249
- https://github.com/SU-SOE/soe_basic/pull/12
- Theming for the Events section
- @imonroe 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
