### PR TITLE
D8CORE-1579: changes to the news list pages for gradient

### DIFF
--- a/config/sync/page_manager.page_variant.stanford_news_list-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_news_list-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-stanford-news-views-header
-        centered: centered-container
-        columns: default
-        label: 'Section - Header'
+        label: 'Heading block'
       components:
         f17fb844-f2a6-4847-8923-bedfc2d39521:
           uuid: f17fb844-f2a6-4847-8923-bedfc2d39521

--- a/config/sync/page_manager.page_variant.stanford_news_list_terms-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_news_list_terms-layout_builder-0.yml
@@ -16,12 +16,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-stanford-news-views-header
-        centered: centered-container
-        columns: default
-        label: 'Section - Header'
+        label: 'Heading block'
       components:
         1d8aa00c-c36f-403c-8c3a-3605cd3762b4:
           uuid: 1d8aa00c-c36f-403c-8c3a-3605cd3762b4


### PR DESCRIPTION
# READY FOR REVIEW
- Should be merged to the 2249 since this branch is branched from there.

# Summary
- Sub theme work for the SOE News module.

# Needed By (Date)
- Tuesday

# Urgency
- Med

# Steps to Test
1. Pull in this branch into the 2249 changes
2. Pull in SOE profile branch
3. Update configs
4. Recompile
5. Check on the pages that they match the designs.

# Affected Projects or Products
- SOE Subtheming

# Affected Pages
/news - filtered and not

# Associated Issues and/or People
- D8CORE-1579
- D8CORE-2131
- D8CORE-2132
- https://github.com/SU-SOE/soe_profile/pull/50
- https://github.com/SU-SOE/soe_basic/pull/12
- Theming for the Events and News section
- @imonroe 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
