### PR TITLE
D8CORE-2249: try again with exporting

### DIFF
--- a/config/sync/page_manager.page_variant.event_series-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.event_series-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-event-series-list--header
-        centered: centered-container
-        columns: default
-        label: Header
+        label: Heading
       components:
         7e322eed-9186-4bef-9e88-f8364e0bd364:
           uuid: 7e322eed-9186-4bef-9e88-f8364e0bd364

--- a/config/sync/page_manager.page_variant.stanford_events_list-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_list-layout_builder-0.yml
@@ -16,12 +16,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-event-list--title
-        centered: centered-container
-        columns: default
-        label: 'Page Title'
+        label: Heading
       components:
         611cbf70-b775-493c-9ec3-4af3397319fe:
           uuid: 611cbf70-b775-493c-9ec3-4af3397319fe

--- a/config/sync/page_manager.page_variant.stanford_events_past-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_past-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-events-past--header
-        centered: centered-container
-        columns: default
-        label: Header
+        label: Heading
       components:
         0f215804-4b92-45c1-a5ab-59eb3b7f3122:
           uuid: 0f215804-4b92-45c1-a5ab-59eb3b7f3122

--- a/config/sync/page_manager.page_variant.stanford_events_upcoming-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_upcoming-layout_builder-0.yml
@@ -14,12 +14,9 @@ variant_settings:
   weight: 0
   sections:
     -
-      layout_id: jumpstart_ui_one_column
+      layout_id: soe_basic_full_width_header
       layout_settings:
-        extra_classes: section-event-list--title
-        centered: centered-container
-        columns: default
-        label: 'Page Title'
+        label: Heading
       components:
         1d61c490-3289-422f-9025-c70415f7ed1b:
           uuid: 1d61c490-3289-422f-9025-c70415f7ed1b


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Sub theme work for the SOE Events module.
- Changed the pages to account for the gradients in css behind the headers. Taking this approach since we will not have our row/cell variants ready when the sites launch.

# Needed By (Date)
- Tuesday

# Urgency
- High

# Steps to Test
1. Pull in this branch
2. Pull in SOE Subtheming branch - 8.x-1.x
3. Update configs
4. Recompile
5. Check on the Affect pages that they match the designs.

# Affected Projects or Products
- SOE Subtheming

# Affected Pages
/events/
/events/class (filtered lists)
/events/past
/event-series
/event/series/soe-event-series

# Associated Issues and/or People
- D8CORE-2247
- D8CORE-2248
- D8CORE-2249
- https://github.com/SU-SOE/soe_basic/pull/12
- Theming for the Events section
- @imonroe 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
