### PR TITLE
D8CORE-2298: moved the h1 above the hero banner image

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -25,6 +25,34 @@ third_party_settings:
       -
         layout_id: jumpstart_ui_one_column
         layout_settings:
+          extra_classes: node-stanford-page-title
+          centered: centered-container
+          columns: default
+          label: ''
+        components:
+          af0809fe-fe61-4e78-be4e-4837cd773c26:
+            uuid: af0809fe-fe61-4e78-be4e-4837cd773c26
+            region: main
+            configuration:
+              id: 'field_block:node:stanford_page:title'
+              label: Title
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: entity_title_heading
+                settings:
+                  tag: h1
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+      -
+        layout_id: jumpstart_ui_one_column
+        layout_settings:
           extra_classes: ''
           centered: null
           columns: default
@@ -42,33 +70,6 @@ third_party_settings:
                 type: entity_reference_revisions_entity_view
                 settings:
                   view_mode: default
-                third_party_settings: {  }
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-            additional: {  }
-            weight: 0
-        third_party_settings: {  }
-      -
-        layout_id: jumpstart_ui_one_column
-        layout_settings:
-          extra_classes: ''
-          centered: centered-container
-          columns: default
-        components:
-          af0809fe-fe61-4e78-be4e-4837cd773c26:
-            uuid: af0809fe-fe61-4e78-be4e-4837cd773c26
-            region: main
-            configuration:
-              id: 'field_block:node:stanford_page:title'
-              label: Title
-              provider: layout_builder
-              label_display: '0'
-              formatter:
-                label: hidden
-                type: entity_title_heading
-                settings:
-                  tag: h1
                 third_party_settings: {  }
               context_mapping:
                 entity: layout_builder.entity

--- a/config/sync/layout_library.layout.stanford_basic_page_full.yml
+++ b/config/sync/layout_library.layout.stanford_basic_page_full.yml
@@ -8,6 +8,33 @@ targetEntityType: node
 targetBundle: stanford_page
 layout:
   -
+    layout_id: defaults
+    layout_settings:
+      extra_classes: node-stanford-page-full-width-title
+      centered: centered-container
+      columns: default
+      label: ''
+    components:
+      6ce9c0ce-a019-44f4-9225-4c2a1a9fbc6d:
+        uuid: 6ce9c0ce-a019-44f4-9225-4c2a1a9fbc6d
+        region: main
+        configuration:
+          id: 'field_block:node:stanford_page:title'
+          label: Title
+          provider: layout_builder
+          label_display: '0'
+          formatter:
+            label: hidden
+            type: entity_title_heading
+            settings:
+              tag: h1
+            third_party_settings: {  }
+          context_mapping:
+            entity: layout_builder.entity
+        additional: {  }
+        weight: 0
+    third_party_settings: {  }
+  -
     layout_id: jumpstart_ui_one_column
     layout_settings:
       extra_classes: ''
@@ -27,32 +54,6 @@ layout:
             type: entity_reference_revisions_entity_view
             settings:
               view_mode: default
-            third_party_settings: {  }
-          context_mapping:
-            entity: layout_builder.entity
-        additional: {  }
-        weight: 0
-    third_party_settings: {  }
-  -
-    layout_id: jumpstart_ui_one_column
-    layout_settings:
-      extra_classes: ''
-      centered: centered-container
-      columns: default
-    components:
-      6ce9c0ce-a019-44f4-9225-4c2a1a9fbc6d:
-        uuid: 6ce9c0ce-a019-44f4-9225-4c2a1a9fbc6d
-        region: main
-        configuration:
-          id: 'field_block:node:stanford_page:title'
-          label: Title
-          provider: layout_builder
-          label_display: '0'
-          formatter:
-            label: hidden
-            type: entity_title_heading
-            settings:
-              tag: h1
             third_party_settings: {  }
           context_mapping:
             entity: layout_builder.entity


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Switching the header and the top banner

# Needed By (Date)
- EOD Friday 7/24

# Urgency
- Med

# Steps to Test

1. Pull in this config change.
1. Clear caches
2. Add a banner to a basic page. See the the title is above the Hero banner image.
3. Try on a no layout and full width layout. Notice NO change to the homepage.

# Affected Projects or Products
- SOE

# Associated Issues and/or People
- D8CORE-2298

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
