### PR TITLE
D8CORE-2132: Fixing the event node header

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -37,18 +37,17 @@ dependencies:
     - text
     - user
     - views
+  theme:
+    - soe_basic
 third_party_settings:
   layout_builder:
     allow_custom: true
     enabled: true
     sections:
       -
-        layout_id: defaults
+        layout_id: soe_basic_full_width_header
         layout_settings:
-          extra_classes: section-editorial-content
-          centered: centered-container
-          columns: default
-          label: 'Editorial Content'
+          label: 'Editorial Content with Background'
         components:
           cee36061-b3bc-4171-92d5-299e62b7d0f2:
             uuid: cee36061-b3bc-4171-92d5-299e62b7d0f2
@@ -60,7 +59,28 @@ third_party_settings:
               label_display: '0'
               context_mapping: {  }
             additional: {  }
-            weight: -10
+            weight: 5
+          229e196d-4f22-4f5a-b265-added1838d5d:
+            uuid: 229e196d-4f22-4f5a-b265-added1838d5d
+            region: main
+            configuration:
+              id: 'field_block:node:stanford_event:su_event_type'
+              label: 'Event Type'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: entity_reference_label
+                settings:
+                  link: true
+                third_party_settings:
+                  field_formatter_class:
+                    class: su-event-type
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 6
           9c246a83-54f9-4f93-a975-e9bdc0259f82:
             uuid: 9c246a83-54f9-4f93-a975-e9bdc0259f82
             region: main
@@ -81,7 +101,7 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: -8
+            weight: 7
           2d7ecccf-4511-455e-ae69-f2b24a376a43:
             uuid: 2d7ecccf-4511-455e-ae69-f2b24a376a43
             region: main
@@ -102,7 +122,7 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: -7
+            weight: 8
           ff876f05-89b3-49c8-9bae-516ac86b4e79:
             uuid: ff876f05-89b3-49c8-9bae-516ac86b4e79
             region: main
@@ -123,7 +143,7 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: -6
+            weight: 9
           625d8b06-94fb-4027-bec0-f39e16810c8a:
             uuid: 625d8b06-94fb-4027-bec0-f39e16810c8a
             region: main
@@ -146,28 +166,7 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: -5
-          229e196d-4f22-4f5a-b265-added1838d5d:
-            uuid: 229e196d-4f22-4f5a-b265-added1838d5d
-            region: main
-            configuration:
-              id: 'field_block:node:stanford_event:su_event_type'
-              label: 'Event Type'
-              provider: layout_builder
-              label_display: '0'
-              formatter:
-                label: hidden
-                type: entity_reference_label
-                settings:
-                  link: true
-                third_party_settings:
-                  field_formatter_class:
-                    class: su-event-type
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-            additional: {  }
-            weight: -9
+            weight: 10
         third_party_settings: {  }
       -
         layout_id: stanford_events_body
@@ -581,6 +580,7 @@ third_party_settings:
         - jumpstart_ui_three_column
         - stanford_events_editorial_content
         - stanford_events_body
+        - soe_basic_full_width_header
 id: node.stanford_event.default
 targetEntityType: node
 bundle: stanford_event


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding a wrapper div for the news vertical teaser.

# Needed By (Date)
- Wednesday

# Urgency
- Med

# Steps to Test

1. Pull in this and the two other branches - SOE Profile and Subtheme
2. Build
3. Verify on a news node that the vertical cards have the blue border bottom on the link and it looks correct.

# Affected Projects or Products
- SOE Subtheme and News 

# Associated Issues and/or People
- D8CORE-2132
- https://github.com/SU-SWS/stanford_news/pull/93
- https://github.com/SU-SOE/soe_basic/pull/15


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
