### PR TITLE
DEVOPS-000: removed field formatter patch again.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,9 +169,6 @@
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2698425": "https://www.drupal.org/files/issues/2020-02-05/2698425--accept-content-updates--122.patch"
             },
-            "drupal/field_formatter_class": {
-                "https://www.drupal.org/project/field_formatter_class/issues/3046372": "https://www.drupal.org/files/issues/2020-02-03/field_formatter_class-3046372-10.patch"
-            },
             "drupal/menu_link_weight": {
                 "https://www.drupal.org/project/menu_link_weight/issues/2995896": "https://www.drupal.org/files/issues/2018-08-29/2995896-menu-admin-per-menu-support-fixes.patch"
             },


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- hotfix to remove the field formatter patch from the composer.json

# Needed By (Date)
- today

# Urgency
- very urgent, will block launch

