### PR TITLE
D8CORE-2614: removed the extra su-button class

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_stories.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_stories.default.yml
@@ -70,7 +70,7 @@ content:
       target: '0'
     third_party_settings:
       field_formatter_class:
-        class: 'su-stories-paragraph__cta su-button'
+        class: su-stories-paragraph__cta
   stanford_stories_name:
     weight: 1
     label: hidden


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the hover on the button. There was an extra su-button class.

# Review By (Date)
- 9/25

# Criticality
- Med
- SOE

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Add a story with a CTA link
3. Verify there is only one hover and not two.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- SOE Paragraph Stories

# Associated Issues and/or People
- D8CORE-2614
- https://github.com/SU-SOE/soe_paragraphs/pull/17

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
