### PR TITLE
Removed double header on person

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - core.base_field_override.node.stanford_person.title
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
+    - field.field.node.stanford_person.su_person_academic_appt
+    - field.field.node.stanford_person.su_person_admin_appts
     - field.field.node.stanford_person.su_person_affiliations
     - field.field.node.stanford_person.su_person_components
     - field.field.node.stanford_person.su_person_education
@@ -24,6 +26,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_profile_link
     - field.field.node.stanford_person.su_person_research
     - field.field.node.stanford_person.su_person_research_interests
+    - field.field.node.stanford_person.su_person_scholarly_interests
     - field.field.node.stanford_person.su_person_short_title
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
@@ -405,7 +408,7 @@ third_party_settings:
               id: 'field_block:node:stanford_person:su_person_telephone'
               label: Contact
               provider: layout_builder
-              label_display: visible
+              label_display: '0'
               formatter:
                 label: hidden
                 type: string

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -6,6 +6,29 @@
 class PersonCest {
 
   /**
+   * Sidebar "Contact" header should only appear once.
+   */
+  public function testDoubleHeader(AcceptanceTester $I){
+    $node = $I->createEntity([
+      'type' => 'stanford_person',
+      'title' => 'Foo Bar',
+      'su_person_first_name' => 'Foo',
+      'su_person_last_name' => 'Bar',
+      'su_person_telephone' => '1234567890',
+    ]);
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSee('Foo Bar', 'h1');
+    $headers = $I->grabMultiple('h2');
+    $contacts = 0;
+    foreach ($headers as $header) {
+      if (strpos(strtolower($header), 'contact') !== FALSE) {
+        $contacts++;
+      }
+    }
+    $I->assertEquals(1, $contacts);
+  }
+
+  /**
    * Test that the default content has installed and is unpublished.
    */
   public function testDefaultContentExists(AcceptanceTester $I) {
@@ -107,7 +130,7 @@ class PersonCest {
    */
   public function testD8Core2613Terms(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
-    
+
     $foo = $I->createEntity([
       'name' => 'Foo',
       'vid' => 'stanford_person_types',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the double header on the person detail page.

# Need Review By (Date)
- asap

# Urgency
- now

# Steps to Test
1. checkout this branch
1. import config
1. create a person content type with some contact fields populated
1. validate only 1 "Contact" header is displayed.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
