### PR TITLE
D8CORE-2548: fixing the load more button to 20 from 10

### DIFF
--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -62,7 +62,7 @@ display:
       pager:
         type: infinite_scroll
         options:
-          items_per_page: 10
+          items_per_page: 20
           offset: 0
           id: 0
           total_pages: null


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixing the load more to 20 to keep from duplication

# Needed By (Date)
- ASAP - possible hotfix?

# Urgency
- High 

# Steps to Test

1. Pull in this change.
2. Update the configs.
3. Generate lots of news articles.
4. Check you get 20 listings on the page. Copy a title.
5. Press Load More.
6. Search for the title to verify there's only one.

# Affected Projects or Products
- SOE

# Associated Issues and/or People
- D8CORE-2548
- @rmundstock 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
