### PR TITLE
D8CORE-3563 Limit the image gallery to one per row

### DIFF
--- a/config/sync/block.block.soe_basic_config_pages_stanford_global_msg.yml
+++ b/config/sync/block.block.soe_basic_config_pages_stanford_global_msg.yml
@@ -6,7 +6,7 @@ dependencies:
     - config_pages
   theme:
     - soe_basic
-id: soe_basic_config_pages_global_msg
+id: soe_basic_config_pages_stanford_global_msg
 theme: soe_basic
 region: help
 weight: 0

--- a/config/sync/core.entity_form_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_page.default.yml
@@ -87,6 +87,7 @@ content:
         stanford_cta_list: 12
         stanford_image_cta: 1
         stanford_stories: 12
+        stanford_gallery: 12
       resizable: false
     weight: 26
     third_party_settings: {  }

--- a/tests/codeception/acceptance/Content/BasicPageCest.php
+++ b/tests/codeception/acceptance/Content/BasicPageCest.php
@@ -11,6 +11,14 @@ use Faker\Factory;
 class BasicPageCest {
 
   /**
+   * Make sure the basic page settings are correct.
+   */
+  public function testComponentSettings(AcceptanceTester $I){
+    $response = $I->runDrush('cget core.entity_form_display.node.stanford_page.default content.su_page_components.settings.sizes');
+    $I->assertStringContainsString('stanford_gallery: 12', $response);
+  }
+
+  /**
    * Test placing a basic page in the menu with a child menu item.
    */
   public function testCreatingPage(AcceptanceTester $I) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The image gallery should only be 1 per row.

# Need Review By (Date)
- 3/3

# Urgency
- high

# Steps to Test
1. checkout this branch
2. drush cim -y
3. create a basic page
4. verify you cant add anything to a row that has an image gallery in it.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
