### PR TITLE
D8CORE-2808: changing the help text to say below the page title

### DIFF
--- a/config/sync/field.field.node.stanford_page.su_page_banner.yml
+++ b/config/sync/field.field.node.stanford_page.su_page_banner.yml
@@ -13,7 +13,7 @@ field_name: su_page_banner
 entity_type: node
 bundle: stanford_page
 label: 'Top Banner'
-description: 'The top banner displays directly below the navigation and on interior pages, above the page title.'
+description: 'The top banner displays directly below the navigation and on interior pages, below the page title.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the help text to say "The top banner displays directly below the navigation and on interior pages, below the page title."

# Needed By (Date)
- 4/30

# Urgency
- Med

# Steps to Test

1. Pull in and import this change.
2. Clear Caches.
3. Add a TOP Banner to a page.
4. Review the help text and confirm it says the correct location of the banner.
5. Verify the Banner React Paragraph not impacted.

# Affected Projects or Products
- SOE Subtheme

# Associated Issues and/or People
- D8CORE-2808

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
